### PR TITLE
Fix utility robustness

### DIFF
--- a/smtpping.cpp
+++ b/smtpping.cpp
@@ -65,7 +65,7 @@ bool debug = false;
  * Signal Handlers (abort ping and show statistics)
  */
 bool abort_ping = false;
-void abort(int)
+void sigint_handler(int)
 {
 	abort_ping = true;
 	signal(SIGINT, SIG_DFL);
@@ -189,7 +189,7 @@ void usage(const char* name, FILE* fp, int status)
 int main(int argc, char* argv[])
 {
 	/* register signal handlers */
-	signal(SIGINT, abort);
+	signal(SIGINT, sigint_handler);
 
 #ifdef __WIN32__
 	/* initialize winsock */

--- a/smtpping.cpp
+++ b/smtpping.cpp
@@ -439,9 +439,13 @@ int main(int argc, char* argv[])
 
 #ifdef SUPPORT_RATE
 	sem_t* sem = (sem_t*)mmap(NULL, sizeof(sem_t), PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+	size_t* counter = (size_t*)mmap(NULL, sizeof(size_t), PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+	if (sem == MAP_FAILED || counter == MAP_FAILED) {
+		fprintf(stderr, "mmap: failed\n");
+		return 1;
+	}
 	if (sem_init(sem, 1, 1) != 0)
 		fprintf(stderr, "sem_init: failed\n");
-	size_t* counter = (size_t*)mmap(NULL, sizeof(size_t), PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
 	*counter = 0;
 #else
 	if (show_rate) {
@@ -461,6 +465,8 @@ int main(int argc, char* argv[])
 			pid = fork();
 			if (pid == 0)
 				goto spawn;
+			if (pid < 0)
+				fprintf(stderr, "fork() failed\n");
 		}
 #ifdef SUPPORT_RATE
 		while (show_rate && !abort_ping) {


### PR DESCRIPTION
- Check `mmap()` and `fork()` return values
- Rename SIGINT handler to avoid shadowing libc `abort()`